### PR TITLE
[Refactor] fix template parsing, fill out function errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .env*
 .idea
-internal/templates
-config/config.yml
+internal/template/templates
+config/property.yml
 config/secret.yml

--- a/internal/template/parser.go
+++ b/internal/template/parser.go
@@ -4,18 +4,35 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 )
 
-const Path = "internal/templates/"
+const templatesDirectoryName = "templates"
 
 func parseTemplateByFormat(template interface{}, templateFileName string) error {
-	templateBytes, err := os.ReadFile(Path + templateFileName)
+	templatePath, err := getTemplateFilePath(templateFileName)
+	if err != nil {
+		return fmt.Errorf("failed to get template file path: %w", err)
+	}
+
+	templateBytes, err := os.ReadFile(templatePath)
 	if err != nil {
 		return fmt.Errorf("failed to read summary prompt promptTemplate: %w", err)
 	}
 
-	if err := json.Unmarshal(templateBytes, &template); err != nil {
+	if err := json.Unmarshal(templateBytes, template); err != nil {
 		return fmt.Errorf("failed to parseFeed summary prompt promptTemplate: %w", err)
 	}
 	return nil
+}
+
+func getTemplateFilePath(templateFileName string) (string, error) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("failed to get runtime caller")
+	}
+
+	basePath := filepath.Dir(filename)
+	return filepath.Join(basePath, templatesDirectoryName, templateFileName), nil
 }

--- a/internal/template/parser_test.go
+++ b/internal/template/parser_test.go
@@ -1,0 +1,38 @@
+package template
+
+import (
+	"testing"
+)
+
+func TestTemplateFillOut(t *testing.T) {
+	t.Run("Test PullRequestTemplate FillOut", func(t *testing.T) {
+		pullRequestTemplate, err := NewPullRequestTemplate()
+		if err != nil {
+			t.Fatalf("failed to create PullRequestTemplate: %v", err)
+		}
+
+		filled, err := pullRequestTemplate.FillOut("memberName", "postTitle", "publishedAt", "postUrl", "summary")
+
+		if err != nil {
+			t.Fatalf("failed to execute PullRequestTemplate: %v", err)
+		}
+
+		t.Log(filled)
+	})
+
+	t.Run("Test SummaryPromptTemplate FillOut", func(t *testing.T) {
+		summaryPromptTemplate, err := NewSummaryPromptTemplate()
+
+		if err != nil {
+			t.Fatalf("failed to create SummaryPromptTemplate: %v", err)
+		}
+
+		filled, err := summaryPromptTemplate.FillOut("타이틀!", "컨텐츠!")
+
+		if err != nil {
+			t.Fatalf("failed to fill filled SummaryPromptTemplate: %v", err)
+		}
+
+		t.Log(filled)
+	})
+}

--- a/internal/template/summarize.go
+++ b/internal/template/summarize.go
@@ -44,8 +44,12 @@ func getSummaryPromptTemplateInstance() (*template.Template, error) {
 		return summaryPromptTemplateInstance, nil
 	}
 
-	var format summaryPromptTemplateFormat
+	format := &summaryPromptTemplateFormat{}
 	err := parseTemplateByFormat(format, summaryPromptTemplateFileName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parseFeed summary prompt promptTemplate : %w", err)
+	}
+
 	summaryPromptTemplateInstance, err = template.New(summaryPromptTemplateFileName).Parse(format.Template)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create summaryPromptTemplate : %w", err)

--- a/internal/util/parser.go
+++ b/internal/util/parser.go
@@ -89,7 +89,7 @@ func createPost(item *gofeed.Item, publishedAt *time.Time) *post.Model {
 	return &post.Model{
 		Title:       item.Title,
 		URL:         item.Link,
-		Content:     item.Content,
+		Content:     item.Description,
 		GUID:        item.GUID,
 		PublishedAt: *publishedAt,
 		CreatedAt:   time.Now(),


### PR DESCRIPTION
1. 템플릿 파일 Load시 올바른 경로를 참조하도록 변경
2. 템플릿 파서에 값을 채울 template format을 전달할 때, 빈 객체를 전달하도록 변경 (이전 nil)
3. rss parsing 이후 템플릿에 값을 채울 때, rss item의 content를 호출했는데, tistory의 경우 Discription에서 글 내용을 얻을 수 있음