### PR TITLE
[Feat] Encrypt secret by sops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
-.env*
+# IDE 설정 파일
 .idea
+
+# 템플릿
 internal/template/templates
+
+# 설정 값
 config/property.yml
 config/secret.yml
+
+# 빌드 파일
+*.tar

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,6 @@
+creation_rules:
+  - path_regex: config/property\.yml
+    unencrypted_regex: '^(logging)$'
+    key_groups:
+      - age:
+        - age1xs3094qjr954kqcqpy02unxpjpq9m8fgvsmurevkqxmsxc9z7dmq52z4jt

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -33,7 +33,7 @@ func main() {
 
 	// Util 초기화
 	postParser := util.NewPostParser()
-	postSummarizer, err := util.NewPostSummarizer(config.OpenAI.APIKey)
+	postSummarizer, err := util.NewPostSummarizer(config.SummaryAssistant.APIKey)
 	if err != nil {
 		logger.Fatal("Failed to initialize post summarizer", logger.Fields{
 			"error": err.Error(),

--- a/config/config.go
+++ b/config/config.go
@@ -24,9 +24,9 @@ type Config struct {
 		Token string `yaml:"token"`
 	} `yaml:"github"`
 
-	OpenAI struct {
+	SummaryAssistant struct {
 		APIKey string `yaml:"api_key"`
-	} `yaml:"openai"`
+	} `yaml:"summary_assistant"`
 
 	Logging struct {
 		Level string `yaml:"level"`

--- a/config/encrypted-property.yml
+++ b/config/encrypted-property.yml
@@ -1,0 +1,37 @@
+server:
+    port: ENC[AES256_GCM,data:mQvaAQ==,iv:Pw8fp9tLjgncA0z9WH1f1ApF6fnRtCe4P02wVI0lOAg=,tag:lAKaJXX2MSMQV4G29P/1AA==,type:int]
+    env: ENC[AES256_GCM,data:Gzg9,iv:yS0qMcFHP+6/sRuAcoIPC+grAsR//2pxePPYOXu7EBM=,tag:uwTjNQTubv8+MyZ8dpms1w==,type:str]
+database:
+    base_url: ENC[AES256_GCM,data:xBeW7Coy9AJzs5i9x9JjL6Omy5AYR8oEg5S+lAffz64wjCwEYnIbOw==,iv:ybxN4pwvQJoG8izAhKB1jcJlNJ/YkDdEyt0OIs/NIhY=,tag:5387GWbmoqjgWAtaG437Bg==,type:str]
+    key: ENC[AES256_GCM,data:MgQ2VL/6mfwwe6KslqolVddyprlY3AxFQfs9VZPxgcHzrYLHFTuVgRNQzozbabpGgIysqD3VclaDwOtgKwTuzHcaxD9OyLARyXgzy+Jrrp9wP60BhUaYf0Ck3BGOnlRZ5vwoWNsFoq/tyFz1GQGSg045fo4ygmcGZIgDxI1OaetS2qylHRLTrQJf5oR6oJibKiBW3ICDnyvJ8vZZ07HINLZL132uSmMXIqg0OPjquz4p0ws/IYzPcXuoDJmw6zrttgHbhi7v1yzyW2uPPTgspw==,iv:Lue+oCXWpb525wLBGLrKdYKj/qquFwkbmTtVWQwsmN4=,tag:Wfv3cIUCdevw+hxyhqnbug==,type:str]
+github:
+    token: ENC[AES256_GCM,data:EhVoZXSO8/bCNvgobHAh4nF5je3RB00mtfLLWz6n5QYDmNE67pLVLw==,iv:ISBHhwJ0S28VJFT0dSvfduZEzrvdkQWm7qUwhrEg/Iw=,tag:B2p/8f7mEwfX0sH8BjQG8w==,type:str]
+summary_assistant:
+    api_key: ENC[AES256_GCM,data:xRvsU2gnvSuP+pbKKUq+DTVeHdPZdk75iLj+ZUssB/qA+VW6+fZPGSWo9WZ1FugreWh1D/rgOqvI5X6yWSECguAqNZU/RyQvt1ADNPOobMPhbh0pXNTAXekHvE03lc0=,iv:cATsUt0wq9REFWXg6y32/abhWJay/0Y5gW8frBs2x54=,tag:pwIFPNkWPyaXpLSP+72/Sg==,type:str]
+logging:
+    level: info
+cors:
+    allow_origins: ENC[AES256_GCM,data:7EJi8r6ziaRorp8/T6Oh9KSC28xDl0vlQ9t4mkeZaibmhQqkvBPqeDfkeimwGRp16mcf,iv:zHgV/wR4ADIkWR1NQgiwbPvFa3NcxZCO2/KOzLdbCSg=,tag:tVUys5WM//gBqYYJt0g0aw==,type:str]
+    allow_methods: ENC[AES256_GCM,data:iqoTxY5YI6PuPFZicvMqNBXD3OaSUA==,iv:oCUdaznJ4aCssLAV8PHiJqsR26XoGjRA6LxDcY1fWpA=,tag:DS3EAUXPhc/+jywxdLDXXg==,type:str]
+    allow_headers: ENC[AES256_GCM,data:696dcM5uOxpJ6KITavMcfJUhJrR0eynU2o0=,iv:RzBMgLXiEc8cb9p+wJks2OF0ruToQ0Wk8IKsPGXjLi0=,tag:M4HbkKAqM0Ets8RWSgBKxA==,type:str]
+    allow_credentials: ENC[AES256_GCM,data:Gd3rPg==,iv:KNj0aUEVSrqJgcveDHNQokOmbRTcP4aebZj448vj/Kw=,tag:aHrATZV+yefj9LF0arTiAA==,type:bool]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1xs3094qjr954kqcqpy02unxpjpq9m8fgvsmurevkqxmsxc9z7dmq52z4jt
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBUNDFObjdMZ1NDc2U1QUpK
+            NTM3aVk3c3ZKa1A0MFUvSXZBbkMrOFNnZHlrCnpTN0FMbXJXdmxxSEFFSVpnWjBt
+            K20rOWlvZUtIaW1WRTJEN3VEd1h2ajAKLS0tIEd6OGsvckI0ZUJVL3hzSGo4RkNI
+            dnV0bTdiN3RSWXREZDhKZ2toNDY2c1UKFRIbNGpZoapLFpouRGrqpFZhdnCRgi12
+            3tF6nEhKladmv3swQ1V2Gd0MwUVdscGQ7m3qIuCB4yZcghcEzbH5lg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-01-17T08:55:46Z"
+    mac: ENC[AES256_GCM,data:b2DWktLK8Tf3E6FWEECV2I60iYVIrPBPO8rD53NInl8/32HktaD+k34RdSn7AHG3JcAPNKZvqCD8bETQIruoSe+6f7o45k+0sWd+xRlAIqQRzGVc1Xbeog6FzxW/1vHdFJhM5VxdyBUKx4GFqdsqTrAsjYzatZKFq3EgLZOlvQc=,iv:RscvzVRlr+2zPPGe3deWtxum384aVf/1d6VrphhZXqw=,tag:QBEHu3I2TTiAGBZgebVZVA==,type:str]
+    pgp: []
+    unencrypted_regex: ^(logging)$
+    version: 3.9.3


### PR DESCRIPTION
Sops를 활용해 property를 encrypt해서 git으로 관리. 
java진영의 jasypt와 유사하게 사용할 수 있다. 공개키로 시크릿을 암호화하고 비공개키로 복호화 한다.

이렇게 한 이유는... 귀찮아서.........................
1. GIthub Actions 같은 CI/CD 툴에 각종 시크릿 값들을 하나 하나 세팅하기가 귀찮았다. 
    변경이 있을 때도 매번 설정해줘야 한다.
    이런 암호화를 쓰면, 암호화 비공개키 하나만 등록하면 되서 좋다. (딸깍 딸깍 캐리 가능하다)
2. 설정파일을 아예 git으로 관리 안 하면 버전 관리가 안되기 때문에, 특정 시점의 설정을 확인하기가 어려움.
    예전에 사이트 운영할 때 한번 곤란했던 적이 있었음
3. golang엔 jasypt가 없어서 sops라는 비슷한 역할의 툴을 썼다. (이름 부터가 Java Simplified Encryption)

